### PR TITLE
fixes a bug that can cause comments to go missing on ajax requests

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -43,7 +43,6 @@ class CommentsController < ApplicationController
     @comment = Comment.find(params[:id])
     authorize @comment
     flash.now[:success] = 'Comment removed!' if @comment.destroy
-    params[:page] = @comment.page_num
   end
 
   private

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -33,7 +33,8 @@ module CommentsHelper
     return unless post && comment
 
     link_to 'Delete',
-            polymorphic_path([comment.commentable, post, comment]),
+            polymorphic_path([comment.commentable, post, comment],
+            page: get_record_index(post.comments, comment)),
             class: "delete-comment-link",
             id: "delete-comment-#{comment.id}",
             data: { target: 'show-comment-delete' }

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -19,4 +19,11 @@ module PaginationHelper
       }
     }
   end
+
+  def get_record_index(collection = nil, record = nil)
+    return unless collection && record
+    return 1 if collection.index(record) == 0
+
+    (collection.index(record).to_f / 25).ceil
+  end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -12,10 +12,6 @@ class Comment < ApplicationRecord
     self.commentable
   end
 
-  def page_num
-    (self.class.where("id <= ?", read_attribute(:id)).order("id asc").count.to_f / 25).ceil
-  end
-
   def self.comment_search(term)
     term ? where('text ILIKE ?', "%#{term}%") : all
   end

--- a/app/views/comments/create.js.erb
+++ b/app/views/comments/create.js.erb
@@ -1,7 +1,9 @@
 $('#comment-form-row').remove();
 $('.flash-container').remove();
 
-$('.section:last').replaceWith("<%= j render('comments/comment_section') %>")
+history.pushState({}, null, "?page=<%= params[:page] %>");
 
-$('body').append("<%= j render('layouts/messages') %>")
-$('.flash-container').animate({ bottom: '+=150px' }, 500).delay(2000).fadeOut(500)
+$('.section:last').replaceWith("<%= j render('comments/comment_section') %>");
+
+$('body').append("<%= j render('layouts/messages') %>");
+$('.flash-container').animate({ bottom: '+=150px' }, 500).delay(2000).fadeOut(500);

--- a/app/views/comments/destroy.js.erb
+++ b/app/views/comments/destroy.js.erb
@@ -2,7 +2,9 @@ $('#comment-form-row').remove();
 $('.flash-container').remove();
 $('#show-comment-delete').modal('close');
 
-$('.section:last').replaceWith("<%= j render('comments/comment_section') %>")
+history.pushState({}, null, "?page=<%= params[:page] %>");
 
-$('body').append("<%= j render('layouts/messages') %>")
-$('.flash-container').animate({ bottom: '+=150px' }, 500).delay(2000).fadeOut(500)
+$('.section:last').replaceWith("<%= j render('comments/comment_section') %>");
+
+$('body').append("<%= j render('layouts/messages') %>");
+$('.flash-container').animate({ bottom: '+=150px' }, 500).delay(2000).fadeOut(500);

--- a/app/views/comments/error.js.erb
+++ b/app/views/comments/error.js.erb
@@ -1,5 +1,5 @@
-$('.flash-container').remove()
+$('.flash-container').remove();
 $('#show-comment-delete').modal('close');
 
-$('body').append("<%= j render('layouts/messages') %>")
-$('.flash-container').animate({ bottom: '+=150px' }, 500).delay(2000).fadeOut(500)
+$('body').append("<%= j render('layouts/messages') %>");
+$('.flash-container').animate({ bottom: '+=150px' }, 500).delay(2000).fadeOut(500);

--- a/app/views/comments/update.js.erb
+++ b/app/views/comments/update.js.erb
@@ -1,7 +1,7 @@
 $('#comment-form-row').remove();
-$('.flash-container').remove()
+$('.flash-container').remove();
 
-$("#comment-<%= @comment.id %>").replaceWith("<%= j render('comments/comment', comment: @comment) %>")
+$("#comment-<%= @comment.id %>").replaceWith("<%= j render('comments/comment', comment: @comment) %>");
 
 $('body').append("<%= j render('layouts/messages') %>");
-$('.flash-container').animate({ bottom: '+=150px' }, 500).delay(2000).fadeOut(500)
+$('.flash-container').animate({ bottom: '+=150px' }, 500).delay(2000).fadeOut(500);

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -8,5 +8,5 @@ Kaminari.configure do |config|
   # config.right = 0
   # config.page_method_name = :page
   # config.param_name = :page
-  # config.params_on_first_page = false
+  config.params_on_first_page = true
 end

--- a/spec/features/comments/users/user_views_paginated_comments_spec.rb
+++ b/spec/features/comments/users/user_views_paginated_comments_spec.rb
@@ -29,6 +29,7 @@ RSpec.feature 'A user views paginated comments', js: true do
     expect(page).to have_text('Comment created!')
     expect(page).to have_text('I agree with myself!')
     expect(find('ul.pagination').find('li.active').find('a').text).to eq('2')
+    expect(all('.comment-item').count).to eq(2)
   end
 
   scenario 'when editing a comment the current page is maintained' do
@@ -52,11 +53,38 @@ RSpec.feature 'A user views paginated comments', js: true do
     click_on '2'
     find("#delete-comment-#{user_post.comments.last.id}").click
 
+    expect(all('.comment-item').count).to eq(1)
     expect(page).to have_text('Are you sure you want to delete this comment?')
 
     find('#delete-comment-modal-link').click
 
     expect(page).to have_text('Comment removed!')
     expect(page).not_to have_selector('ul', class: 'pagination')
+    expect(all('.comment-item').count).to eq(25)
+  end
+
+  scenario 'when removing a comment the current page should be kept' do
+    click_on 'New Comment'
+
+    expect(page).to have_selector('#new_comment')
+
+    fill_in 'comment_text', with: 'I agree with myself!'
+    click_on 'Submit'
+
+    expect(page).to have_text('Comment created!')
+    expect(page).to have_text('I agree with myself!')
+    expect(find('ul.pagination').find('li.active').find('a').text).to eq('2')
+    expect(all('.comment-item').count).to eq(2)
+
+    find("#delete-comment-#{user_post.comments.last.id}").click
+
+    expect(page).to have_text('Are you sure you want to delete this comment?')
+
+    find('#delete-comment-modal-link').click
+
+    expect(page).to have_text('Comment removed!')
+    expect(page).not_to have_text('I agree with myself!')
+    expect(find('ul.pagination').find('li.active').find('a').text).to eq('2')
+    expect(all('.comment-item').count).to eq(1)
   end
 end

--- a/spec/helpers/pagination_helper_spec.rb
+++ b/spec/helpers/pagination_helper_spec.rb
@@ -1,4 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe PaginationHelper, :type => :helper do
+
+  let(:comments) { build_list(:comment, 27, commentable: build(:user), post: build(:current_user_post)) }
+
+  def first_comment
+    comments.first
+  end
+
+  def last_comment
+    comments.last
+  end
+
+  describe '#get_record_index' do
+    it 'returns the page number for a record given a collection' do
+      expect(get_record_index(comments, first_comment)).to eq(1)
+      expect(get_record_index(comments, last_comment)).to eq(2)
+    end
+  end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -4,15 +4,4 @@ RSpec.describe Comment, type: :model do
   it { should belong_to(:commentable) }
   it { should belong_to(:post) }
   it { should validate_presence_of(:text) }
-
-  describe '#page_num' do
-
-    let(:comment_list) { create(:current_user_post_comment_pack).comments }
-
-    it 'returns the page number for a given paginated comment' do
-      expect(comment_list.length).to eq(26)
-      expect(comment_list.first.page_num).to eq(1)
-      expect(comment_list.last.page_num).to eq(2)
-    end
-  end
 end


### PR DESCRIPTION
This fixes a bug where the app was handling the page param for kaminari incorrectly and thus could result in comments not displaying properly.

It also pushes the page param into the browsers history state to set the correct page after ajax comment manipulation.